### PR TITLE
Removed conflict marker from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 /sites/default/**/files
 /sites/default/**/private
 
-<<<<<<< HEAD
 # Settings
 sites/default/settings.php
 


### PR DESCRIPTION
It seems there was a conflict marker in `.gitignore`. Removed it.